### PR TITLE
link not found page to redirect to /posts route

### DIFF
--- a/react-app/src/components/NotFoundPage/index.js
+++ b/react-app/src/components/NotFoundPage/index.js
@@ -6,7 +6,7 @@ export default function NotFoundPage(){
     return (
         <div className='notfoundpage-container'>
             <h1>Sorry, this page isn't available.</h1>
-            <h3>The link you followed may be broken, or the page may have been removed.<Link to='/'>Go back to Grammygram.</Link> </h3>
+            <h3>The link you followed may be broken, or the page may have been removed.<Link to='/posts'>Go back to Grammygram.</Link> </h3>
         </div>
     )
 }


### PR DESCRIPTION
fix bug on 404 route page to show redirect direct to the feed